### PR TITLE
Allow skipping of mtime in database store

### DIFF
--- a/git-meta
+++ b/git-meta
@@ -48,7 +48,9 @@ def run(cmd, ignore_errors=False):
 
 def get_file_stats(f, args):
     st = os.stat(f)
-    ret = { 'mode': st.st_mode, 'mtime': int(st.st_mtime) }
+    ret = { 'mode': st.st_mode }
+    if args['skip_mtime'] is False:
+        ret['mtime'] = int(st.st_mtime)
     if args['numeric_owner'] is True:
         ret['uid'] = st.st_uid
         ret['gid'] = st.st_gid
@@ -155,7 +157,7 @@ def parse_cmd_line():
                       default=False, action='store_true')
     args.add_argument('-P', '--skip-perms', help='Skip perms during restore',
                       default=False, action='store_true')
-    args.add_argument('-M', '--skip-mtime', help='Skip mtime during restore',
+    args.add_argument('-M', '--skip-mtime', help='Skip mtime during store/restore',
                       default=False, action='store_true')
     args.add_argument('-v', '--verbose', help='Show operations',
                       default=False, action='store_true')


### PR DESCRIPTION
The user may wish to completely disable mtime setting during the restore
of the database.  For doing that, she can use "git-meta set -M".
However, since the mtime key is always stored in the database, the
.gitmeta file may indicate, in some cases (for instance, when moving
files around without modifying them), modification times that are not
relevant.  This is annoying, because irrelevant changes keep getting
tracked uselessly by Git.

This commit avoids this, by preventing the mtime key to be stored when
option -M is used with "git-meta get".  The documentation string has
also been changed accordingly.

Note that it would also be interesting to have the same behavior for the
-U and -G options, but, in the current state of the code if neither -o
or -O options are given, the get_file_stats does not store uid and gid
information in the database, which amounts to skipping owner information
storage in "git-meta get".
