### PR TITLE
Fix logic for setting perms and mtime in git_set_file_attributs

### DIFF
--- a/git-meta
+++ b/git-meta
@@ -109,10 +109,10 @@ def git_set_file_attributs(args):
     data = load_metadata(args)
     for file in data.keys():
         if args['verbose']: sys.stdout.write('%s:' % file)
-        if (args['skip_perms'] is False) or not(data[file].has_key('mode')):
+        if (args['skip_perms'] is False) and data[file].has_key('mode'):
             if args['verbose']: sys.stdout.write(' mode:%6o' % data[file]['mode'])
             os.chmod(file, data[file]['mode'])
-        if (args['skip_mtime'] is False)  or not(data[file].has_key('mtime')):
+        if (args['skip_mtime'] is False) and data[file].has_key('mtime'):
             if args['verbose']: sys.stdout.write(' mtime:%s' % datetime.datetime.fromtimestamp(data[file]['mtime']).strftime('%Y-%m-%d %H:%M:%S'))
             os.utime(file, (data[file]['mtime'], data[file]['mtime']))
         uid = -1


### PR DESCRIPTION
The modification file of a file must be set only if the argument
skip_perms (viz skipt_mtime) is false AND the the data dictionary for
that file has the 'mode' (viz. 'mtime') key.
