### PR TITLE
Do not follow symlinks in getting/setting file attributes

### DIFF
--- a/git-meta
+++ b/git-meta
@@ -1,4 +1,4 @@
-#!/usr/bin/python
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 
 """
@@ -39,7 +39,7 @@ def run(cmd, ignore_errors=False):
     out, err = proc.communicate()
     rc = proc.returncode
     if rc == 0 or ignore_errors:
-        return out
+        return out.decode('UTF-8')
     else:
         sys.stdout.write("Failed (%s): %s\n" %
                          (rc, ' '.join(pipes.quote(arg) for arg in cmd)))
@@ -47,7 +47,7 @@ def run(cmd, ignore_errors=False):
         sys.exit(1)
 
 def get_file_stats(f, args):
-    st = os.stat(f)
+    st = os.stat(f, follow_symlinks=False)
     ret = { 'mode': st.st_mode, 'mtime': int(st.st_mtime) }
     if args['numeric_owner'] is True:
         ret['uid'] = st.st_uid
@@ -69,7 +69,7 @@ def git_get_files_attributs(args):
             continue
         rows[f] = get_file_stats(f, args)
         while not (f == '' or f == '.'):
-            if not rows.has_key(f):
+            if not f in rows:
                 rows[f] = get_file_stats(f, args)
             f = os.path.dirname(f)
     metadata = open(args['data'], 'w')
@@ -93,44 +93,45 @@ def dump_database(args):
     print('%s %s %s %s %s' %( 'mode'.center(6), 'mtime'.center(19), 'uid'.center(6), 'gid'.center(6), 'file' ))
     for entry in entries:
         row = ['%.6o' % data[entry]['mode']]
-        if data[entry].has_key('mtime'):
+        if 'mtime' in data[entry]:
             row.append(datetime.datetime.fromtimestamp(data[entry]['mtime']).strftime('%Y-%m-%d %H:%M:%S'))
-        if data[entry].has_key('uid'):
+        if 'uid' in data[entry]:
             row.append('%6s' % data[entry]['uid'])
-        if data[entry].has_key('gid'):
+        if 'gid' in data[entry]:
             row.append('%6s' % data[entry]['gid'])
         if os.path.isfile(entry):
             row.append(entry)
         else:
             row.append('%s/' % entry)
-        print ' '.join(row)
+        print(' '.join(row))
 
 def git_set_file_attributs(args):
     data = load_metadata(args)
     for file in data.keys():
         if args['verbose']: sys.stdout.write('%s:' % file)
-        if (args['skip_perms'] is False) or not(data[file].has_key('mode')):
-            if args['verbose']: sys.stdout.write(' mode:%6o' % data[file]['mode'])
-            os.chmod(file, data[file]['mode'])
-        if (args['skip_mtime'] is False)  or not(data[file].has_key('mtime')):
+        if (args['skip_perms'] is False) or not('mode' in data[file]):
+            if not os.path.islink(file):
+                if args['verbose']: sys.stdout.write(' mode:%6o' % data[file]['mode'])
+                os.chmod(file, data[file]['mode'])
+        if (args['skip_mtime'] is False)  or not('mtime' in data[file]):
             if args['verbose']: sys.stdout.write(' mtime:%s' % datetime.datetime.fromtimestamp(data[file]['mtime']).strftime('%Y-%m-%d %H:%M:%S'))
-            os.utime(file, (data[file]['mtime'], data[file]['mtime']))
+            os.utime(file, (data[file]['mtime'], data[file]['mtime']), follow_symlinks=False)
         uid = -1
         gid = -1
-        if (args['skip_user'] is False) and data[file].has_key('uid') or \
-           (args['skip_group'] is False) and data[file].has_key('gid'):
-            if (args['skip_user'] is False) and data[file].has_key('uid'):
+        if (args['skip_user'] is False) and ('uid' in data[file]) or \
+           (args['skip_group'] is False) and ('gid' in data[file]):
+            if (args['skip_user'] is False) and ('uid' in data[file]):
                 if isinstance(data[file]['uid'], int):
                     uid = data[file]['uid']
                 else:
                     uid = pwd.getpwnam(data[file]['uid']).pw_uid
-            if (args['skip_group'] is False) and data[file].has_key('gid'):
+            if (args['skip_group'] is False) and ('gid' in data[file]):
                 if isinstance(data[file]['gid'], int):
                     gid = data[file]['gid']
                 else:
                     gid = grp.getgrnam(data[file]['gid']).gr_gid
             if args['verbose']: sys.stdout.write(' user:%s group:%s' % (uid, gid))
-            os.chown(file, uid, gid)
+            os.chown(file, uid, gid, follow_symlinks=False)
         if args['verbose']: sys.stdout.write('\n')
 
 


### PR DESCRIPTION
This is done by using the argument follow_symlinks=False of functions
os.stat, os.utime, and os.chown.  The os.chmod function does not accept
that argument in Linux, simply because symlinks do not have
permissions.  Hence, we check whether the file is a symlink with
os.path.islink, before calling os.chmod.

These changes force the use of Python v3 and the code need to be
adjusted in several places:

1) One of the print statements needs to be changed by adding
parenthesis around its argument, because print is a function in Python 3.
2) The has_key() methods are replaced by the 'in' operator.
3) The string returned by subprocess.Popen.communicate is now a buffer
interface and needs to be decoded into UTF-8.
