### PR TITLE
Sort entries in the JSON metadata file

### DIFF
--- a/git-meta
+++ b/git-meta
@@ -62,7 +62,6 @@ def git_get_files_attributs(args):
     """ """
     out = run(['git', 'ls-files', '-z'])
     files=out.split('\0')
-    files.sort()
     rows = {}
     for f in files:
         if not(os.path.isfile(f)):
@@ -73,7 +72,7 @@ def git_get_files_attributs(args):
                 rows[f] = get_file_stats(f, args)
             f = os.path.dirname(f)
     metadata = open(args['data'], 'w')
-    json.dump(rows, metadata, indent=0)
+    json.dump(rows, metadata, indent=0, sort_keys=True)
     metadata.close()
     if args['add_to_git']:
         run(['git', 'add', args['data']])


### PR DESCRIPTION
Add the argument 'sort_keys=True' to the json.dump call, such that the
entries are sorted in the metadata file.  This seems to be necessary in
order to avoid gratuitous ordering changes in the metadata file, which
happen in successive calls "git meta get".

Also, this commits removes a useless statement "files.sort()".
