### PR TITLE
Do not follow symlinks in getting/setting file attributes

### DIFF
--- a/git-meta
+++ b/git-meta
@@ -110,10 +110,16 @@ def dump_database(args):
 
 def git_set_file_attributes(args):
     data = load_metadata(args)
-    ## Check for availability of -h option of touch
-    v = run (['touch', '--version']).split('\n') [0]
-    m = re.match (r'touch \(GNU coreutils\) ([\d.]+)', v)
-    touch_has_noderef = m and (StrictVersion(m.group(1)) >= StrictVersion('8.1'))
+    ## Check for availability of -h option of touch (only in Linux)
+    if sys.platform == "linux" or sys.platform == "linux2":
+        v = run (['touch', '--version']).split('\n') [0]
+        m = re.match (r'touch \(GNU coreutils\) ([\d.]+)', v)
+        touch_has_noderef = m and (StrictVersion(m.group(1)) >= StrictVersion('8.1'))
+    else:
+        if sys.platform == "darwin":
+            touch_has_noderef = True
+        else:
+            touch_has_noderef = False
     for file in data.keys():
         if args['verbose']: sys.stdout.write('%s:' % file)
         if (args['skip_perms'] is False) and data[file].has_key('mode'):

--- a/git-meta
+++ b/git-meta
@@ -29,6 +29,8 @@ import json
 import argparse
 import datetime
 import re
+from distutils.version import StrictVersion
+from time import gmtime, strftime
 
 def run(cmd, ignore_errors=False):
     """run cmd"""
@@ -47,7 +49,7 @@ def run(cmd, ignore_errors=False):
         sys.exit(1)
 
 def get_file_stats(f, args):
-    st = os.stat(f)
+    st = os.lstat(f)
     ret = { 'mode': st.st_mode }
     if args['skip_mtime'] is False:
         ret['mtime'] = int(st.st_mtime)
@@ -108,14 +110,25 @@ def dump_database(args):
 
 def git_set_file_attributes(args):
     data = load_metadata(args)
+    ## Check for availability of -h option of touch
+    v = run (['touch', '--version']).split('\n') [0]
+    m = re.match (r'touch \(GNU coreutils\) ([\d.]+)', v)
+    touch_has_noderef = m and (StrictVersion(m.group(1)) >= StrictVersion('8.1'))
     for file in data.keys():
         if args['verbose']: sys.stdout.write('%s:' % file)
         if (args['skip_perms'] is False) and data[file].has_key('mode'):
-            if args['verbose']: sys.stdout.write(' mode:%6o' % data[file]['mode'])
-            os.chmod(file, data[file]['mode'])
+           if not os.path.islink(file):
+               if args['verbose']: sys.stdout.write(' mode:%6o' % data[file]['mode'])
+               os.chmod(file, data[file]['mode'])
         if (args['skip_mtime'] is False) and data[file].has_key('mtime'):
             if args['verbose']: sys.stdout.write(' mtime:%s' % datetime.datetime.fromtimestamp(data[file]['mtime']).strftime('%Y-%m-%d %H:%M:%S'))
-            os.utime(file, (data[file]['mtime'], data[file]['mtime']))
+            if os.path.islink(file):
+                if touch_has_noderef:
+                    run(['touch', '-h', '-t',
+                         strftime ('%Y%m%d%H%M.%S', gmtime(data[file]['mtime'])),
+                         file])
+            else:
+                os.utime(file, (data[file]['mtime'], data[file]['mtime']))
         uid = -1
         gid = -1
         if (args['skip_user'] is False) and data[file].has_key('uid') or \
@@ -131,7 +144,7 @@ def git_set_file_attributes(args):
                 else:
                     gid = grp.getgrnam(data[file]['gid']).gr_gid
             if args['verbose']: sys.stdout.write(' user:%s group:%s' % (uid, gid))
-            os.chown(file, uid, gid)
+            os.lchown(file, uid, gid)
         if args['verbose']: sys.stdout.write('\n')
 
 


### PR DESCRIPTION
This is achieved in a quite convoluted way, but which works in Python2.
Note that an equivalent in Python3 would be much simpler, because all
the involved os.\* functions accept the argument 'follow_symlink=False'.

Here is the description of the changes in this commit:

1) Call os.lstat() for getting the file attributes.

2) Use os.lchown() for changing the gid and uid of the file.

3) If the file is a symbolic link, then does not call os.chmod() on it,
since it is not possible to change permissions of symbolic links (at
least in Linux).

4) Since there is no "os.lutime()" in the Python os module, the setting
of mtime is done done by calling of the touch system utility, with the
appropriate option "-t".  This function is widely available, so there
should be no problem in introducing this call.  However, in order to not
follow symlinks when touching, option "-h" must be used.  This option
appeared in version 8.1 of GNU coreutils.  In order to avoid errors, the
version of touch in the system is tested and he symbolic link's mtime is
adjusted only if GNU coureutils' touch is used AND if its version is >=
8.1. (Note that, for this to work, the distutils.version module is
imported).  Furthermore, the format of the date accepted by option -t of
the touch command is "YYYYmmddHHMM.SS".  Functions time.strftime() and
time.gmtime() are used for converting from the format returned by
os.lstat().  Note that the mtime is converted to GMT.
