### PR TITLE
Do not skip dangling symbolic links

### DIFF
--- a/git-meta
+++ b/git-meta
@@ -68,7 +68,7 @@ def git_get_files_attributes(args):
     files=out.split('\0')
     rows = {}
     for f in files:
-        if not(os.path.isfile(f)):
+        if not(os.path.isfile(f)) and not(os.path.islink(f)):
             continue
         rows[f] = get_file_stats(f, args)
         while not (f == '' or f == '.'):


### PR DESCRIPTION
It may happen that a symbolic link under Git control points to
nowhere.  In this case, the information about the symbolic link
must still be stored in the database.  Since os.path.isfile follows
symlinks, the test for the existence of symlink entries failed and
those entries were skipped in function git_get_files_attributes.
This commit fixes this problem.
